### PR TITLE
SystemUI: add better hints when trying to delete edit tile

### DIFF
--- a/packages/SystemUI/res/anim/ic_qs_tile_delete_disable_cross_anim.xml
+++ b/packages/SystemUI/res/anim/ic_qs_tile_delete_disable_cross_anim.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+<objectAnimator
+    android:duration="350"
+    android:propertyName="pathData"
+    android:valueFrom="M 4.4 3 L 4.7 3.3"
+    android:valueTo="M 4.4 3 L 21 19.6"
+    android:valueType="pathType"
+    android:interpolator="@interpolator/ic_hotspot_disable_cross_1_pathdata_interpolator" />
+<objectAnimator
+    android:duration="17"
+    android:propertyName="strokeAlpha"
+    android:valueFrom="0"
+    android:valueTo="1"
+    android:interpolator="@android:interpolator/linear" />
+</set>

--- a/packages/SystemUI/res/anim/ic_qs_tile_delete_disable_mask_anim.xml
+++ b/packages/SystemUI/res/anim/ic_qs_tile_delete_disable_mask_anim.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+<objectAnimator
+    android:duration="350"
+    android:propertyName="pathData"
+    android:valueFrom="M24,24H0V0h1.4l2.9,3l1.4-1.4L4.2,0H24V24z"
+    android:valueTo="M24,24H0V0h1.4l19.8,19.8l1.4-1.4L4.2,0H24V24z"
+    android:valueType="pathType"
+    android:interpolator="@android:interpolator/fast_out_slow_in" />
+</set>

--- a/packages/SystemUI/res/anim/ic_qs_tile_delete_disable_root_anim.xml
+++ b/packages/SystemUI/res/anim/ic_qs_tile_delete_disable_root_anim.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+<objectAnimator
+    android:duration="350"
+    android:propertyName="alpha"
+    android:valueFrom="1.0"
+    android:valueTo="0.3"
+    android:interpolator="@android:interpolator/fast_out_slow_in" />
+</set>

--- a/packages/SystemUI/res/drawable/ic_qs_tile_delete.xml
+++ b/packages/SystemUI/res/drawable/ic_qs_tile_delete.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2015 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6 19c0 1.1 .9 2 2 2h8c1.1 0 2-.9 2-2v-12h-12v12zm13-15h-3.5l-1-1h-5l-1
+1h-3.5v2h14v-2z" />
+</vector>

--- a/packages/SystemUI/res/drawable/ic_qs_tile_delete_disable.xml
+++ b/packages/SystemUI/res/drawable/ic_qs_tile_delete_disable.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:name="root"
+    android:alpha="1"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <clip-path
+        android:name="mask"
+        android:pathData="M24,24H0V0h1.4l2.9,3l1.4-1.4L4.2,0H24V24z" />
+    <path
+        android:name="cross"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="3.2"
+        android:strokeAlpha="0"
+        android:pathData="M 4.4 3 L 4.7 3.3" />
+    <path
+        android:name="bin"
+        android:fillColor="#FFFFFFFF"
+        android:fillAlpha="1"
+        android:pathData="M6,19c0,1.1,0.9,2,2,2h8c1.1,0,2-0.9,2-2V7H6V19z
+M19,4h-3.5l-1-1h-5l-1,1H5v2h14V4z" />
+</vector>

--- a/packages/SystemUI/res/drawable/ic_qs_tile_delete_disable_avd.xml
+++ b/packages/SystemUI/res/drawable/ic_qs_tile_delete_disable_avd.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/ic_qs_tile_delete_disable" >
+    <target
+        android:name="root"
+        android:animation="@anim/ic_qs_tile_delete_disable_root_anim" />
+    <target
+        android:name="mask"
+        android:animation="@anim/ic_qs_tile_delete_disable_mask_anim" />
+    <target
+        android:name="cross"
+        android:animation="@anim/ic_qs_tile_delete_disable_cross_anim" />
+</animated-vector>

--- a/packages/SystemUI/res/drawable/ic_qs_tile_delete_enable.xml
+++ b/packages/SystemUI/res/drawable/ic_qs_tile_delete_enable.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:name="root"
+    android:alpha="0.3"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <clip-path
+        android:name="mask"
+        android:pathData="M24,24H0V0h1.4l19.8,19.8l1.4-1.4L4.2,0H24V24z" />
+    <path
+        android:name="cross"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="3.2"
+        android:strokeAlpha="1"
+        android:pathData="M 4.4 3 L 21 19.6" />
+    <path
+        android:name="bin"
+        android:fillColor="#FFFFFFFF"
+        android:fillAlpha="1"
+        android:pathData="M6,19c0,1.1,0.9,2,2,2h8c1.1,0,2-0.9,2-2V7H6V19z
+M19,4h-3.5l-1-1h-5l-1,1H5v2h14V4z" />
+</vector>

--- a/packages/SystemUI/res/values/cm_colors.xml
+++ b/packages/SystemUI/res/values/cm_colors.xml
@@ -75,11 +75,12 @@
     <color name="qs_row_text_color">@android:color/white</color>
 
     <!-- natural color of the trash can -->
-    <color name="qs_tile_trash">#FFFFFF</color>
+    <color name="qs_tile_trash_normal_tint">@android:color/transparent</color>
     <!-- tint to color trash can when tile is hovering over it -->
-    <color name="qs_tile_trash_delete_tint">#FF0000</color>
-    <!-- tint to color trash can when hovering edit tile, user cannot delete it -->
-    <color name="qs_tile_trash_delete_tint_warning">#FF9C00</color>
+    <color name="qs_tile_trash_delete_tint">#EF5350</color>
+    <!-- Tint to color trash can when hovering edit tile, user cannot delete it.
+         Transparent because we have an animation by default. -->
+    <color name="qs_tile_trash_delete_tint_warning">@android:color/transparent</color>
 
     <!-- More exposed hard coded colors -->
     <color name="toggle_slider_text_color">#666666</color>

--- a/packages/SystemUI/src/com/android/systemui/qs/QSDragPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSDragPanel.java
@@ -32,6 +32,7 @@ import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.PointF;
 import android.graphics.PorterDuff;
+import android.graphics.drawable.Animatable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
@@ -142,10 +143,6 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
 
         mQsPanelTop = (QSPanelTopView) LayoutInflater.from(mContext).inflate(R.layout.qs_tile_top,
                 this, false);
-
-        // tint trash can to default color
-        final int color = mContext.getColor(R.color.qs_tile_trash);
-        DrawableCompat.setTint(mQsPanelTop.getDropTargetIcon().getDrawable(), color);
 
         mBrightnessView = mQsPanelTop.getBrightnessView();
         mFooter = new QSFooter(this, mContext);
@@ -965,6 +962,7 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
                         Log.v(TAG, "ACTION_DRAG_STARTED on target view.");
                     }
                     mRestored = false;
+                    mQsPanelTop.setDropIcon(R.drawable.ic_qs_tile_delete_disable, R.color.qs_tile_trash_normal_tint);
                 }
 
                 break;
@@ -981,16 +979,17 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
                 mMovedByLocation = false;
 
                 if (v == mQsPanelTop) {
-                    int color;
+                    int icon, color;
                     if (mDraggingRecord.tile instanceof EditTile) {
                         // use a different warning, user can't erase this one
-                        color = mContext.getColor(R.color.qs_tile_trash_delete_tint_warning);
+                        icon = R.drawable.ic_qs_tile_delete_disable_avd;
+                        color = R.color.qs_tile_trash_delete_tint_warning;
                     } else {
-                        color = mContext.getColor(R.color.qs_tile_trash_delete_tint);
+                        icon = R.drawable.ic_qs_tile_delete_disable;
+                        color = R.color.qs_tile_trash_delete_tint;
                     }
 
-                    DrawableCompat.setTint(mQsPanelTop.getDropTargetIcon().getDrawable(), color);
-                    mQsPanelTop.getDropTargetIcon().invalidate();
+                    mQsPanelTop.setDropIcon(icon, color);
                 }
 
                 if (!originatingTileEvent && v != getDropTarget() && targetTile != null) {
@@ -1057,9 +1056,7 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
                 }
 
                 if (v == mQsPanelTop) {
-                    final int color = mContext.getColor(R.color.qs_tile_trash);
-                    DrawableCompat.setTint(mQsPanelTop.getDropTargetIcon().getDrawable(), color);
-                    mQsPanelTop.getDropTargetIcon().invalidate();
+                    mQsPanelTop.setDropIcon(R.drawable.ic_qs_tile_delete_disable, R.color.qs_tile_trash_normal_tint);
                 }
 
                 if (originatingTileEvent

--- a/packages/SystemUI/src/com/android/systemui/qs/QSPanelTopView.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSPanelTopView.java
@@ -23,8 +23,12 @@ import android.annotation.Nullable;
 import android.app.ActivityManager;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.Animatable;
+import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.os.UserHandle;
+import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -158,6 +162,18 @@ public class QSPanelTopView extends FrameLayout {
     public void onStartDrag() {
         mDisplayingTrash = true;
         animateToState();
+    }
+
+    public void setDropIcon(int resourceId, int colorResourceId) {
+        mDropTargetIcon.setImageResource(resourceId);
+        final Drawable drawable = mDropTargetIcon.getDrawable();
+
+        DrawableCompat.setTintMode(drawable, PorterDuff.Mode.SRC_ATOP);
+        DrawableCompat.setTint(drawable, mContext.getColor(colorResourceId));
+
+        if (drawable instanceof Animatable) {
+            ((Animatable) drawable).start();
+        }
     }
 
     public void toast(int textStrResId) {


### PR DESCRIPTION
Add a clearer indication that the edit tile cannot be deleted via an
animation.

Animations by Asher Simonds.

Ref: CYNGNOS-1644

Change-Id: I829faface9268cd2900533f8194bdfe58339420c
Signed-off-by: Roman Birg roman@cyngn.com
