### PR TITLE
SystemUI: improve exiting edit mode from qs settings

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/QSDragPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSDragPanel.java
@@ -390,34 +390,42 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
         }
     }
 
+    private void persistRecords() {
+        // persist the new config.
+        List<String> newTiles = new ArrayList<>();
+        for (TileRecord record : mRecords) {
+            newTiles.add(mHost.getSpec(record.tile));
+        }
+        mHost.setTiles(newTiles);
+    }
+
     public void setEditing(boolean editing) {
         if (mEditing == editing) return;
-        mEditing = editing;
+        final boolean isOnSettings = isOnSettingsPage();
 
+        mQsPanelTop.setEditing(editing, isOnSettings);
         if (!editing) {
-            // persist the new config.
-            List<String> newTiles = new ArrayList<>();
-            for (TileRecord record : mRecords) {
-                newTiles.add(mHost.getSpec(record.tile));
-            }
-            mHost.setTiles(newTiles);
+            persistRecords();
 
             refreshAllTiles();
 
-            mQsPanelTop.animate().translationX(0).start();
+            mQsPanelTop.setTranslationX(0);
+            if (isOnSettings) {
+                mViewPager.setCurrentItem(1, true);
+            }
         }
+        mEditing = editing;
+        mPagerAdapter.notifyDataSetChanged();
+
+        mPageIndicator.setEditing(editing);
+        mViewPager.setOffscreenPageLimit(mEditing ? getCurrentMaxPageCount() + 1 : 1);
+        mPagerAdapter.notifyDataSetChanged();
 
         // clear the record state
         for (TileRecord record : mRecords) {
             setupRecord(record);
             drawTile(record, record.tile.getState());
         }
-        mQsPanelTop.setEditing(editing);
-        mPageIndicator.setEditing(editing);
-        mPagerAdapter.notifyDataSetChanged();
-
-        mViewPager.setOffscreenPageLimit(mEditing ? getCurrentMaxPageCount() + 1 : 1);
-        mPagerAdapter.notifyDataSetChanged();
 
         requestLayout();
     }
@@ -2110,8 +2118,8 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
                     CMSettings.Secure.QS_USE_MAIN_TILES, 1, currentUserId) == 1;
             if (firstRowLarge != mFirstRowLarge) {
                 mFirstRowLarge = firstRowLarge;
-                setTiles(new ArrayList<QSTile<?>>()); // clear out states
                 setTiles(mHost.getTiles());
+                mPagerAdapter.notifyDataSetChanged();
             }
         }
     }

--- a/packages/SystemUI/src/com/android/systemui/qs/QSPanelTopView.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSPanelTopView.java
@@ -65,6 +65,7 @@ public class QSPanelTopView extends FrameLayout {
 
     private SettingsObserver mSettingsObserver;
     private boolean mListening;
+    private boolean mSkipAnimations;
 
     public QSPanelTopView(Context context, @Nullable AttributeSet attrs) {
         this(context, attrs, 0);
@@ -137,12 +138,11 @@ public class QSPanelTopView extends FrameLayout {
         boolean animateToState = !isLaidOut();
         super.onLayout(changed, left, top, right, bottom);
         if (animateToState) {
-            Log.e(TAG, "first layout animating to state!");
-            animateToState();
+            goToState();
         }
     }
 
-    public void setEditing(boolean editing) {
+    public void setEditing(boolean editing, boolean skipAnim) {
         mEditing = editing;
         if (editing) {
             mDisplayingInstructions = true;
@@ -151,7 +151,11 @@ public class QSPanelTopView extends FrameLayout {
             mDisplayingInstructions = false;
             mDisplayingTrash = false;
         }
-        animateToState();
+        if (skipAnim) {
+            goToState();
+        } else {
+            animateToState();
+        }
     }
 
     public void onStopDrag() {
@@ -254,9 +258,9 @@ public class QSPanelTopView extends FrameLayout {
                 }
             });
 
-            mAnimator.setDuration(500);
+            mAnimator.setDuration(mSkipAnimations ? 0 : 500);
             mAnimator.setInterpolator(new FastOutSlowInInterpolator());
-            mAnimator.setStartDelay(100);
+            mAnimator.setStartDelay(mSkipAnimations ? 0 : 100);
             mAnimator.playTogether(instructionAnimator, trashAnimator,
                     brightnessAnimator, toastAnimator);
             mAnimator.start();
@@ -271,6 +275,12 @@ public class QSPanelTopView extends FrameLayout {
     }
 
     private void animateToState() {
+        mSkipAnimations = false;
+        post(mAnimateRunnable);
+    }
+
+    private void goToState() {
+        mSkipAnimations = true;
         post(mAnimateRunnable);
     }
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarHeaderView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarHeaderView.java
@@ -776,7 +776,7 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
 
     public void setEditing(boolean editing) {
         mEditing = editing;
-        if (mEditingDetailAdapter == null) {
+        if (editing && mEditingDetailAdapter == null) {
             mEditingDetailAdapter = new QSTile.DetailAdapter() {
                 @Override
                 public int getTitle() {


### PR DESCRIPTION
When the user hits done while in edit mode on the QS Settings page, the
animation can be a little jarring to move to the first page while the
brightness view slides into place. So let's immediately put the
brightness view into its proper position when going out of editing mode
on the settings page.

Ref: OPO-425

Change-Id: I93794a94752978b1055911bbef19ee9f0d77bd3c
Signed-off-by: Roman Birg roman@cyngn.com
