### PR TITLE
NetworkPolicyManager: Null check list of packages belonging to UID

### DIFF
--- a/services/core/java/com/android/server/net/NetworkPolicyManagerService.java
+++ b/services/core/java/com/android/server/net/NetworkPolicyManagerService.java
@@ -2227,11 +2227,13 @@ public class NetworkPolicyManagerService extends INetworkPolicyManager.Stub {
 
     private boolean isUidIdle(int uid) {
         final String[] packages = mContext.getPackageManager().getPackagesForUid(uid);
-        final int userId = UserHandle.getUserId(uid);
 
-        for (String packageName : packages) {
-            if (!mUsageStats.isAppIdle(packageName, uid, userId)) {
-                return false;
+        if (packages != null) {
+            final int userId = UserHandle.getUserId(uid);
+            for (String packageName : packages) {
+                if (!mUsageStats.isAppIdle(packageName, uid, userId)) {
+                    return false;
+                }
             }
         }
         return true;


### PR DESCRIPTION
- getPackagesForUid can return null instead of an empty collection.

REF: CYNGNOS-1967
Change-Id: I53b1903a0f037d9fb9165c2294106867e9a639e7
