### PR TITLE
SystemUI: remember deleted custom tiles

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/QSDragPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSDragPanel.java
@@ -53,6 +53,7 @@ import com.android.internal.logging.MetricsLogger;
 import com.android.systemui.FontSizeUtils;
 import com.android.systemui.R;
 import com.android.systemui.cm.UserContentObserver;
+import com.android.systemui.qs.tiles.CustomQSTile;
 import com.android.systemui.qs.tiles.EditTile;
 import com.android.systemui.settings.BrightnessController;
 import com.android.systemui.settings.ToggleSlider;
@@ -364,7 +365,11 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
 
     protected void drawTile(TileRecord r, QSTile.State state) {
         if (mEditing) {
-            state.visible = true;
+            if ((r.tile instanceof CustomQSTile) && ((CustomQSTile) r.tile).isUserRemoved()) {
+                // don't modify visibility state.
+            } else {
+                state.visible = true;
+            }
         }
         final int visibility = state.visible ? VISIBLE : GONE;
         setTileVisibility(r.tileView, visibility);
@@ -1082,6 +1087,17 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
                             }
                         });
                         break;
+                    } else if (mDraggingRecord.tile instanceof CustomQSTile) {
+                        ((CustomQSTile) mDraggingRecord.tile).setUserRemoved(true);
+                        final String spec = mHost.getSpec(mDraggingRecord.tile);
+                        restoreDraggingTilePosition(v, new Runnable() {
+                            @Override
+                            public void run() {
+                                // it might get added back later by the app, but that's ok,
+                                // we just want to reset its position after it has been removed.
+                                mHost.remove(spec);
+                            }
+                        });
                     } else {
                         mRestored = true;
                         removeDraggingRecord();
@@ -1898,6 +1914,26 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
                 }
             }
 
+            final Map<String, ?> stringMap = CustomQSTile.getCustomQSTilePrefs(mContext).getAll();
+            for (Map.Entry<String, ?> entry : stringMap.entrySet()) {
+                if (entry.getValue() instanceof Boolean) {
+                    if ((Boolean)entry.getValue()) {
+                        final String key = entry.getKey();
+                        if (QSUtils.isDynamicQsTile(key)) {
+                            mPackageTileMap.get(PACKAGE_ANDROID).add(key);
+                        } else {
+                            final String customTilePackage = getCustomTilePackage(key);
+                            List<String> packageList = mPackageTileMap.get(customTilePackage);
+                            if (packageList == null) {
+                                mPackageTileMap.put(customTilePackage, packageList = new ArrayList<>());
+                            }
+                            packageList.add(key);
+
+                        }
+                    }
+                }
+            };
+
             final List<String> systemTiles = mPackageTileMap.get(PACKAGE_ANDROID);
             Collections.sort(systemTiles);
         }
@@ -1967,6 +2003,7 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
                 // special icon
                 systemOrAppIcon.setImageResource(R.drawable.ic_qs_tile_category_system);
             } else {
+                group = getPackageLabel(group);
                 systemOrAppIcon.setImageResource(R.drawable.ic_qs_tile_category_other);
             }
             title.setText(group);
@@ -2104,7 +2141,21 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
                 public boolean onChildClick(ExpandableListView parent, View v,
                                             int groupPosition, int childPosition, long id) {
                     String spec = getChild(groupPosition, childPosition);
-                    mPanel.add(spec);
+
+                    final QSTile<?> tile = mHost.getTile(spec);
+                    if (tile != null && tile instanceof CustomQSTile) {
+                        // already present
+                        ((CustomQSTile) tile).setUserRemoved(false);
+                        mPanel.refreshAllTiles();
+                    } else {
+                        // reset its state just in case it's not published
+                        CustomQSTile.getCustomQSTilePrefs(mContext)
+                                .edit()
+                                .remove(spec)
+                                .apply();
+                        mPanel.add(spec);
+                        // TODO notify user the app isn't publishing the tile, but it now can be!
+                    }
                     mPanel.closeDetail();
                     return true;
                 }

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/CustomQSTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/CustomQSTile.java
@@ -19,6 +19,7 @@ package com.android.systemui.qs.tiles;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.ThemeConfig;
 import android.net.Uri;
@@ -53,6 +54,8 @@ import java.util.Arrays;
 
 public class CustomQSTile extends QSTile<QSTile.State> {
 
+    private static final String HIDDEN_TILES_PREF_NAME = "user_hidden_qs_tiles";
+
     private CustomTile.ExpandedStyle mExpandedStyle;
     private PendingIntent mOnClick;
     private PendingIntent mOnLongClick;
@@ -61,10 +64,36 @@ public class CustomQSTile extends QSTile<QSTile.State> {
     private StatusBarPanelCustomTile mTile;
     private CustomQSDetailAdapter mDetailAdapter;
     private boolean mCollapsePanel;
+    private boolean mUserRemoved;
 
     public CustomQSTile(Host host, StatusBarPanelCustomTile tile) {
         super(host);
         mTile = tile;
+        mUserRemoved = getIsUserRemovedPersisted();
+    }
+
+    private boolean getIsUserRemovedPersisted() {
+        return getCustomQSTilePrefs(mContext).getBoolean(getTile().getKey(), false);
+    }
+
+    public boolean isUserRemoved() {
+        return mUserRemoved;
+    }
+
+    public void setUserRemoved(boolean removed) {
+        if (mUserRemoved != removed) {
+            if (removed) {
+                getCustomQSTilePrefs(mContext).edit().putBoolean(getTile().getKey(), true).apply();
+            } else {
+                getCustomQSTilePrefs(mContext).edit().remove(getTile().getKey()).apply();
+            }
+            mUserRemoved = removed;
+            refreshState();
+        }
+    }
+
+    public static SharedPreferences getCustomQSTilePrefs(Context context) {
+        return context.getSharedPreferences(HIDDEN_TILES_PREF_NAME, Context.MODE_PRIVATE);
     }
 
     @Override
@@ -138,11 +167,12 @@ public class CustomQSTile extends QSTile<QSTile.State> {
     protected void handleUpdateState(State state, Object arg) {
         if (arg instanceof StatusBarPanelCustomTile) {
             mTile = (StatusBarPanelCustomTile) arg;
+            mUserRemoved = getIsUserRemovedPersisted();
         }
         final CustomTile customTile = mTile.getCustomTile();
         state.contentDescription = customTile.contentDescription;
         state.label = customTile.label;
-        state.visible = true;
+        state.visible = !mUserRemoved;
         final int iconId = customTile.icon;
         if (iconId != 0 && (customTile.remoteIcon == null)) {
             final String iconPackage = mTile.getResPkg();


### PR DESCRIPTION
We previously had no mechanism of knowing which tiles the user had
manually removed, leading to the tiles returning when the publishing
application decided it was time to update.

Now, when the user removes a custom tile; set a flag and hide it in the
tile list. The removed tiles will be enumerated in the Add tile detail
view if the user decides they want it back.

Ticket: CYNGNOS-2530

Change-Id: Ia4fe74ef580af7139279a2fb78e240e872f8dbb0
Signed-off-by: Roman Birg roman@cyngn.com
