### PR TITLE
SystemUI: avoid lock screen shortcut picker crash

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/cm/LockscreenShortcutsActivity.java
+++ b/packages/SystemUI/src/com/android/systemui/cm/LockscreenShortcutsActivity.java
@@ -235,8 +235,10 @@ public class LockscreenShortcutsActivity extends Activity implements View.OnClic
 
     private void onTargetChange(String uri) {
         if (uri == null) {
-            final GlowBackground background = (GlowBackground) mSelectedView.getBackground();
-            background.hideGlow();
+            if (mSelectedView != null) {
+                final GlowBackground background = (GlowBackground) mSelectedView.getBackground();
+                background.hideGlow();
+            }
             return;
         }
 


### PR DESCRIPTION
Fixes crash when picking lock screen shortcut app, then rotating, then
hitting the back button.

Ticket: FEIJ-299

Change-Id: I728052878ca3fc87243878ef96acea2e052aed6d
Signed-off-by: Roman Birg roman@cyngn.com
