### PR TITLE
Add config to show HD icon on EVS codec.

### DIFF
--- a/telephony/java/android/telephony/CarrierConfigManager.java
+++ b/telephony/java/android/telephony/CarrierConfigManager.java
@@ -422,6 +422,13 @@ public class CarrierConfigManager {
     public static final String KEY_HIDE_IMS_APN_BOOL = "hide_ims_apn_bool";
 
     /**
+     * Determine whether HD icon should displayed when audio codec is EVS.
+     * @hide
+     */
+    public static final String KEY_IMS_SUPPORT_EVS_HD_ICON_BOOL =
+            "carrier_ims_support_evs_hd_icon_bool";
+
+    /**
      * Determine whether preferred network type can be shown.
      * @hide
      */
@@ -576,6 +583,7 @@ public class CarrierConfigManager {
         sDefaults.putBoolean(KEY_SUPPORT_CONFERENCE_CALL_BOOL, true);
         sDefaults.putBoolean(KEY_EDITABLE_ENHANCED_4G_LTE_BOOL, true);
         sDefaults.putBoolean(KEY_HIDE_IMS_APN_BOOL, false);
+        sDefaults.putBoolean(KEY_IMS_SUPPORT_EVS_HD_ICON_BOOL, false);
         sDefaults.putBoolean(KEY_HIDE_PREFERRED_NETWORK_TYPE_BOOL, false);
         sDefaults.putBoolean(KEY_EDITABLE_WFC_MODE_BOOL, true);
         sDefaults.putInt(KEY_CDMA_DTMF_TONE_DELAY_INT, 100);


### PR DESCRIPTION
Add config to show HD icon when audio codec is EVS_WB, EVS_SWB
and EVS_FB.
Default value is false.

Change-Id: I6c6b9fc413ba1298522d8c661b50f458a71a2aa7
CRs-fixed: 986961
